### PR TITLE
Update ptyprocess version to v0.7.0

### DIFF
--- a/all/ptyprocess/__init__.py
+++ b/all/ptyprocess/__init__.py
@@ -1,4 +1,4 @@
 """Run a subprocess in a pseudo terminal"""
 from .ptyprocess import PtyProcess, PtyProcessUnicode, PtyProcessError
 
-__version__ = '0.5.2'
+__version__ = '0.7.0'

--- a/all/ptyprocess/_fork_pty.py
+++ b/all/ptyprocess/_fork_pty.py
@@ -4,6 +4,7 @@ import os
 import errno
 
 from pty import (STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO, CHILD)
+from .util import PtyProcessError
 
 def fork_pty():
     '''This implements a substitute for the forkpty system call. This
@@ -63,7 +64,7 @@ def pty_make_controlling_tty(tty_fd):
     try:
         fd = os.open("/dev/tty", os.O_RDWR | os.O_NOCTTY)
         os.close(fd)
-        raise ExceptionPexpect("OSError of errno.ENXIO should be raised.")
+        raise PtyProcessError("OSError of errno.ENXIO should be raised.")
     except OSError as err:
         if err.errno != errno.ENXIO:
             raise

--- a/all/ptyprocess/util.py
+++ b/all/ptyprocess/util.py
@@ -65,3 +65,7 @@ except ImportError:
                     if _access_check(name, mode):
                         return name
         return None
+
+
+class PtyProcessError(Exception):
+    """Generic error class for this package."""


### PR DESCRIPTION
Hello @randy3k !  This PR updates ptyprocess to (latest) v0.7.0.

Note : I've adapted the patch to remove (upstream) trailing whitespaces and keep your workaround for `resource` Python module.

Thanks (again), bye :wave: 